### PR TITLE
Add a weak reference to Webkit framework for iOS

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -134,5 +134,6 @@
         <source-file src="src/ios/SwiftData.swift"/>
         <source-file src="src/ios/SwiftyJson.swift"/>
         <framework src="libsqlite3.dylib"/>
+        <framework src="WebKit.framework" weak="true" />
     </platform>
 </plugin>


### PR DESCRIPTION
The `WKWebView` class is referenced in the code [here](https://github.com/Telerik-Verified-Plugins/Geofencing/blob/master/src/ios/GeofencePlugin.swift#L152) which requires a weak link to the Webkit framework. Without said weak link Xcode fails the build during the linking phase with the error: 

```
Undefined symbols for architecture arm64:
  "_OBJC_CLASS_$_WKWebView", referenced from:
      function signature specialization <Arg[0] = Owned To Guaranteed and Exploded> of Cordova500.GeofencePlugin.evaluateJs (Swift.String) -> () in GeofencePlugin.o
```

Ping @EddyVerbruggen 
Note that I will open a PR in the upstream too, however I don't know if that will be merged or not, so I'm opening one here too.
